### PR TITLE
Refactor to support mocking google API

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ To use it within your own code
 ```go
 import "github.com/ezzarghili/recaptcha-go"
 func main(){
-    recaptcha.Init (recaptchaSecret) // get your secret from https://www.google.com/recaptcha/admin
+    captcha := recaptcha.NewReCAPTCHA(recaptchaSecret) // get your secret from https://www.google.com/recaptcha/admin
 }
 ```
 
 Now everytime you need to verify a client request use
 
 ```go
-success, err :=recaptcha.Verify(recaptchaResponse, ClientRemoteIP)
+success, err := captcha.Verify(recaptchaResponse, ClientRemoteIP)
 if err !=nil {
     // do something with err (log?)
 }
@@ -34,7 +34,7 @@ if err !=nil {
 or
 
 ```go
-success, err :=recaptcha.VerifyNoRemoteIP(recaptchaResponse)
+success, err := captcha.VerifyNoRemoteIP(recaptchaResponse)
 if err !=nil {
     // do something with err (log?)
 }
@@ -46,6 +46,13 @@ while `recaptchaResponse` is the form value with name `g-recaptcha-response` sen
 Both `recaptcha.Verify` and `recaptcha.VerifyNoRemoteIP` return a `bool` and `error` values `(bool, error)`
 
 Use the `error` to check for issues with the secret and connection in the server, and use the `bool` value to verify if the client answered the challenge correctly
+
+### Run Tests
+Use the standard go means of running test.
+
+```
+go test
+```
 
 ### Issues with this library
 

--- a/recaptcha.go
+++ b/recaptcha.go
@@ -4,12 +4,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"time"
 )
-
-var recaptchaSecret string
 
 const reCAPTCHALink = "https://www.google.com/recaptcha/api/siteverify"
 
@@ -26,38 +25,51 @@ type reCHAPTCHAResponse struct {
 	ErrorCodes  []string  `json:"error-codes,omitempty"`
 }
 
-// Init initialize with the reCAPTCHA secret optained from https://www.google.com/recaptcha/admin
-func Init(ReCAPTCHASecret string) {
-	recaptchaSecret = ReCAPTCHASecret
+// custom client so we can mock in tests
+type netClient interface {
+	Post(url string, contentType string, body io.Reader) (resp *http.Response, err error)
+}
+
+type ReCAPTCHA struct {
+	client        netClient
+	Secret        string
+	reCAPTCHALink string
+}
+
+// Create new ReCAPTCHA with the reCAPTCHA secret optained from https://www.google.com/recaptcha/admin
+func NewReCAPTCHA(ReCAPTCHASecret string) (ReCAPTCHA, error) {
+	if ReCAPTCHASecret == "" {
+		return ReCAPTCHA{}, fmt.Errorf("Recaptcha secret cannot be blank.")
+	}
+	return ReCAPTCHA{
+		client: &http.Client{
+			// Go http client does not set a default timeout for request, so we need
+			// to set one for worse cases when the server hang, we need to make this available in the API
+			// to make it possible this library's users to change it, for now a 10s timeout seems reasonable
+			Timeout: 10 * time.Second,
+		},
+		Secret:        ReCAPTCHASecret,
+		reCAPTCHALink: reCAPTCHALink,
+	}, nil
 }
 
 // Verify returns (true, nil) if  no error the client answered the challenge correctly and have correct remoteIP
-func Verify(challengeResponse string, remoteIP string) (bool, error) {
-	body := reCHAPTCHARequest{Secret: recaptchaSecret, Response: challengeResponse, RemoteIP: remoteIP}
-	return confirm(body)
+func (r *ReCAPTCHA) Verify(challengeResponse string, remoteIP string) (bool, error) {
+	body := reCHAPTCHARequest{Secret: r.Secret, Response: challengeResponse, RemoteIP: remoteIP}
+	return r.confirm(body)
 }
 
 // VerifyNoRemoteIP returns (true, nil) if no error and the client answered the challenge correctly
-func VerifyNoRemoteIP(challengeResponse string) (bool, error) {
-	body := reCHAPTCHARequest{Secret: recaptchaSecret, Response: challengeResponse}
-	return confirm(body)
+func (r *ReCAPTCHA) VerifyNoRemoteIP(challengeResponse string) (bool, error) {
+	body := reCHAPTCHARequest{Secret: r.Secret, Response: challengeResponse}
+	return r.confirm(body)
 }
 
-func confirm(recaptcha reCHAPTCHARequest) (Ok bool, Err error) {
+func (r *ReCAPTCHA) confirm(recaptcha reCHAPTCHARequest) (Ok bool, Err error) {
 	Ok, Err = false, nil
-	if recaptcha.Secret == "" {
-		Err = fmt.Errorf("recaptcha secret has not been set, please set recaptcha.Init(secret) before calling verification functions")
-		return
-	}
-	// Go http client does not set a default timeout for request, so we need
-	// to set one for worse cases when the server hang, we need to make this available in the API
-	// to make it possible this library's users to change it, for now a 10s timeout seems reasonable
-	netClient := &http.Client{
-		Timeout: 10 * time.Second,
-	}
 
 	formValue := []byte(`secret=` + recaptcha.Secret + `&response=` + recaptcha.Response)
-	response, err := netClient.Post(
+	response, err := r.client.Post(
 		reCAPTCHALink,
 		"application/x-www-form-urlencoded; charset=utf-8",
 		bytes.NewBuffer(formValue),

--- a/recaptcha.go
+++ b/recaptcha.go
@@ -31,9 +31,9 @@ type netClient interface {
 }
 
 type ReCAPTCHA struct {
-	client        netClient
+	Client        netClient
 	Secret        string
-	reCAPTCHALink string
+	ReCAPTCHALink string
 }
 
 // Create new ReCAPTCHA with the reCAPTCHA secret optained from https://www.google.com/recaptcha/admin
@@ -42,14 +42,14 @@ func NewReCAPTCHA(ReCAPTCHASecret string) (ReCAPTCHA, error) {
 		return ReCAPTCHA{}, fmt.Errorf("Recaptcha secret cannot be blank.")
 	}
 	return ReCAPTCHA{
-		client: &http.Client{
+		Client: &http.Client{
 			// Go http client does not set a default timeout for request, so we need
 			// to set one for worse cases when the server hang, we need to make this available in the API
 			// to make it possible this library's users to change it, for now a 10s timeout seems reasonable
 			Timeout: 10 * time.Second,
 		},
 		Secret:        ReCAPTCHASecret,
-		reCAPTCHALink: reCAPTCHALink,
+		ReCAPTCHALink: reCAPTCHALink,
 	}, nil
 }
 
@@ -69,8 +69,8 @@ func (r *ReCAPTCHA) confirm(recaptcha reCHAPTCHARequest) (Ok bool, Err error) {
 	Ok, Err = false, nil
 
 	formValue := []byte(`secret=` + recaptcha.Secret + `&response=` + recaptcha.Response)
-	response, err := r.client.Post(
-		reCAPTCHALink,
+	response, err := r.Client.Post(
+		r.ReCAPTCHALink,
 		"application/x-www-form-urlencoded; charset=utf-8",
 		bytes.NewBuffer(formValue),
 	)

--- a/recaptcha_test.go
+++ b/recaptcha_test.go
@@ -1,0 +1,134 @@
+package recaptcha
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) { TestingT(t) }
+
+type ReCaptchaSuite struct{}
+
+var _ = Suite(&ReCaptchaSuite{})
+
+type mockSuccessClient struct{}
+
+func (*mockSuccessClient) Post(url string, contentType string, body io.Reader) (resp *http.Response, err error) {
+	resp = &http.Response{
+		Status:     "200 OK",
+		StatusCode: 200,
+	}
+	resp.Body = ioutil.NopCloser(strings.NewReader(`
+	{
+		"success": true,
+		"challenge_ts": "2018-03-06T03:41:29+00:00",
+		"hostname": "test.com"
+	}
+	`))
+	return
+}
+
+type mockFailedClient struct{}
+
+func (*mockFailedClient) Post(url string, contentType string, body io.Reader) (resp *http.Response, err error) {
+	resp = &http.Response{
+		Status:     "200 OK",
+		StatusCode: 200,
+	}
+	resp.Body = ioutil.NopCloser(strings.NewReader(`
+	{
+		"success": false,
+		"challenge_ts": "2018-03-06T03:41:29+00:00",
+		"hostname": "test.com",
+		"error-codes": ["bad-request"]
+	}
+	`))
+	return
+}
+
+type mockInvalidClient struct{}
+
+// bad json body
+func (*mockInvalidClient) Post(url string, contentType string, body io.Reader) (resp *http.Response, err error) {
+	resp = &http.Response{
+		Status:     "200 OK",
+		StatusCode: 200,
+	}
+	resp.Body = ioutil.NopCloser(strings.NewReader(` bogus json `))
+	return
+}
+
+type mockUnavailableClient struct{}
+
+func (*mockUnavailableClient) Post(url string, contentType string, body io.Reader) (resp *http.Response, err error) {
+	resp = &http.Response{
+		Status:     "Not Found",
+		StatusCode: 404,
+	}
+	resp.Body = ioutil.NopCloser(nil)
+	err = fmt.Errorf("Unable to connect to server")
+	return
+}
+
+func (s *ReCaptchaSuite) TestNewReCAPTCHA(c *C) {
+	captcha, err := NewReCAPTCHA("my secret")
+	c.Assert(err, IsNil)
+	c.Check(captcha.Secret, Equals, "my secret")
+	c.Check(captcha.reCAPTCHALink, Equals, reCAPTCHALink)
+
+	captcha, err = NewReCAPTCHA("")
+	c.Assert(err, NotNil)
+}
+
+func (s *ReCaptchaSuite) TestVerifyWithClientIP(c *C) {
+	captcha := ReCAPTCHA{
+		client: &mockSuccessClient{},
+	}
+
+	success, err := captcha.Verify("mycode", "127.0.0.1")
+	c.Assert(err, IsNil)
+	c.Check(success, Equals, true)
+
+	captcha.client = &mockFailedClient{}
+	success, err = captcha.Verify("mycode", "127.0.0.1")
+	c.Assert(err, IsNil)
+	c.Check(success, Equals, false)
+}
+
+func (s *ReCaptchaSuite) TestVerifyWithoutClientIP(c *C) {
+	captcha := ReCAPTCHA{
+		client: &mockSuccessClient{},
+	}
+
+	success, err := captcha.VerifyNoRemoteIP("mycode")
+	c.Assert(err, IsNil)
+	c.Check(success, Equals, true)
+
+	captcha.client = &mockFailedClient{}
+	success, err = captcha.VerifyNoRemoteIP("mycode")
+	c.Assert(err, IsNil)
+	c.Check(success, Equals, false)
+}
+
+func (s *ReCaptchaSuite) TestConfirm(c *C) {
+	// check that an invalid json body errors
+	captcha := ReCAPTCHA{
+		client: &mockInvalidClient{},
+	}
+	body := reCHAPTCHARequest{Secret: "", Response: ""}
+
+	success, err := captcha.confirm(body)
+	c.Assert(err, NotNil)
+	c.Check(success, Equals, false)
+
+	captcha.client = &mockUnavailableClient{}
+	success, err = captcha.confirm(body)
+	c.Assert(err, NotNil)
+	c.Check(success, Equals, false)
+}

--- a/recaptcha_test.go
+++ b/recaptcha_test.go
@@ -80,7 +80,7 @@ func (s *ReCaptchaSuite) TestNewReCAPTCHA(c *C) {
 	captcha, err := NewReCAPTCHA("my secret")
 	c.Assert(err, IsNil)
 	c.Check(captcha.Secret, Equals, "my secret")
-	c.Check(captcha.reCAPTCHALink, Equals, reCAPTCHALink)
+	c.Check(captcha.ReCAPTCHALink, Equals, reCAPTCHALink)
 
 	captcha, err = NewReCAPTCHA("")
 	c.Assert(err, NotNil)
@@ -88,14 +88,14 @@ func (s *ReCaptchaSuite) TestNewReCAPTCHA(c *C) {
 
 func (s *ReCaptchaSuite) TestVerifyWithClientIP(c *C) {
 	captcha := ReCAPTCHA{
-		client: &mockSuccessClient{},
+		Client: &mockSuccessClient{},
 	}
 
 	success, err := captcha.Verify("mycode", "127.0.0.1")
 	c.Assert(err, IsNil)
 	c.Check(success, Equals, true)
 
-	captcha.client = &mockFailedClient{}
+	captcha.Client = &mockFailedClient{}
 	success, err = captcha.Verify("mycode", "127.0.0.1")
 	c.Assert(err, IsNil)
 	c.Check(success, Equals, false)
@@ -103,14 +103,14 @@ func (s *ReCaptchaSuite) TestVerifyWithClientIP(c *C) {
 
 func (s *ReCaptchaSuite) TestVerifyWithoutClientIP(c *C) {
 	captcha := ReCAPTCHA{
-		client: &mockSuccessClient{},
+		Client: &mockSuccessClient{},
 	}
 
 	success, err := captcha.VerifyNoRemoteIP("mycode")
 	c.Assert(err, IsNil)
 	c.Check(success, Equals, true)
 
-	captcha.client = &mockFailedClient{}
+	captcha.Client = &mockFailedClient{}
 	success, err = captcha.VerifyNoRemoteIP("mycode")
 	c.Assert(err, IsNil)
 	c.Check(success, Equals, false)
@@ -119,7 +119,7 @@ func (s *ReCaptchaSuite) TestVerifyWithoutClientIP(c *C) {
 func (s *ReCaptchaSuite) TestConfirm(c *C) {
 	// check that an invalid json body errors
 	captcha := ReCAPTCHA{
-		client: &mockInvalidClient{},
+		Client: &mockInvalidClient{},
 	}
 	body := reCHAPTCHARequest{Secret: "", Response: ""}
 
@@ -127,7 +127,7 @@ func (s *ReCaptchaSuite) TestConfirm(c *C) {
 	c.Assert(err, NotNil)
 	c.Check(success, Equals, false)
 
-	captcha.client = &mockUnavailableClient{}
+	captcha.Client = &mockUnavailableClient{}
 	success, err = captcha.confirm(body)
 	c.Assert(err, NotNil)
 	c.Check(success, Equals, false)


### PR DESCRIPTION
Fixes https://github.com/ezzarghili/recaptcha-go/issues/5

Refactored the code base to be more friendly with writing tests for this repo (and other code bases that utilizes this package).

I should also note that this does make other improvements. For one, you can now use multiple recaptcha's if you want (ie having different secrets). Also, we fail earlier when trying to init our struct with a blank secret (rather than waiting til we execute a confirmation)

cc @ezzarghili 